### PR TITLE
Use "did-stop-loading" event in "continue"

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -183,7 +183,7 @@ app.on('ready', function() {
       ready();
     } else {
       parent.emit('log', 'navigating...');
-      win.webContents.once('did-finish-load', function() {
+      win.webContents.once('did-stop-loading', function() {
         parent.emit('log', 'navigated to: ' + win.webContents.getUrl());
         ready();
       });


### PR DESCRIPTION
The formerly used "did-finish-load" is not always emitted after an action
in case webContents.isLoading() is true. Thus the "continue" event is never
emitted. The probability of this behavior rises with rising frequency
of actions, resulting in flaky behavior and hangs depending on the
target site.

The electron documentation states that "did-finish-load" is only
dispatched when the "onload" event is dispatched and the spinner of the
tab has stopped spinning. Yet the "onload" event is not always dispatched
when webContents.isLoading() is true. Therfore the correct event is
"did-stop-loading" which is always dispatched after isLoading()
transitions to false.